### PR TITLE
Use symlink to display contents of preset readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,1 @@
-# Enhanced react style
-
-Please check out the [babel-preset-enhanced-react-style](https://github.com/cerebral/enhanced-react-style/tree/next/packages/babel-preset-enhanced-react-style) for more information.
+packages/babel-preset-enhanced-react-style/README.md


### PR DESCRIPTION
Hey, thanks for this project, [I think it's really cool](https://twitter.com/karlhorky/status/1140652946016931840)!

Here's a quick PR that uses a symlink to immediately display the contents of the Preset Readme ([GitHub supports this](https://github.com/karlhorky/github-tricks#readme-symlinks)).

Maybe this would be more desirable than having users manually navigate to it?